### PR TITLE
handle Krause files from recent SwissMaster

### DIFF
--- a/lib/icu_tournament/tournament_krause.rb
+++ b/lib/icu_tournament/tournament_krause.rb
@@ -433,11 +433,18 @@ module ICU
           full_byes << round
           return 0.0
         end
-        data = "#{data} -" if data.match(/^\d+ (w|b|-)$/)
-        raise "invalid result '#{data}'" unless data.match(/^(0{1,4}|[1-9]\d{0,3}) (w|b|-) (1|0|=|\+|-)$/)
-        opponent = $1.to_i
-        colour   = $2
-        score    = $3
+        data = "#{data} -" if data.match(/^(\d+)? (w|b|-)$/)
+        if data.match(/^(0{1,4}|[1-9]\d{0,3}) (w|b|-) (1|0|=|\+|-)$/)
+          opponent = $1.to_i
+          colour   = $2
+          score    = $3
+        elsif data.match(/- (1|0|=|\+|-)$/)
+          opponent = 0
+          colour = "-"
+          score = $1
+        else
+          raise "invalid result '#{data}'"
+        end
         options  = Hash.new
         options[:opponent] = opponent unless opponent == 0
         options[:colour]   = colour   unless colour == '-'

--- a/spec/samples/krause/cork_major_2018_swissmaster.tab
+++ b/spec/samples/krause/cork_major_2018_swissmaster.tab
@@ -1,0 +1,38 @@
+012 Cork Congress Majors 2018 1200-1600
+022 Cork
+032 IRL
+042 2018/10/05
+052 2018/10/07
+062 23
+072 22
+082 0
+092 Individual: swiss-system (standard)
+102 Ted Jennings
+112 
+122 1:30+30sec
+132                                                                                        18/10/05  18/10/05  18/10/06  18/10/06  18/10/06  18/10/07
+
+001    1 m    Condon, Gerard                    1516 IRL       17551 1980/  /    3.5    9    13 w 1    11 b 1     4 w =       - =    12 b 0     8 w =  
+001    2 m    Doran, Desmond                    1513 IRL       10931 1999/  /    4.0    7    14 b 0    15 w 1     8 b 0    13 w 1    23 b 1    20 w 1  
+001    3 m    O'Connell, Denis                  1498 IRL        5963 1963/  /    3.0   11    15 w 1    23 b 1     5 w =     4 b 0    10 w =     6 b 0  
+001    4 m    Geaney-O'Brien, David             1474 IRL       13635 1998/  /    5.0    1    16 b 1    10 w 1     1 b =     3 w 1     8 b 1    12 w =  
+001    5 m    Foran, Barry                      1469 IRL        5342 1952/  /    4.5    2    17 w 1    24 b 1     3 b =     8 w 0    15 w 1    14 b 1  
+001    6 m    Mihaylova, Aliona                 1468 IRL       17853 2002/  /    4.0    8    18 b 1    14 w 0    12 b 0    19 w 1    11 b 1     3 w 1  
+001    7 m    Fitzgerald, Niall                 1462 IRL       13609 2003/  /    2.0   19       - =     8 w 0    23 b 0    21 b =    18 w 1    15 b 0  
+001    8 m    Mullins, Niki                     1457            3575 1977/  /    4.0    5    19 w =     7 b 1     2 w 1     5 b 1     4 w 0     1 b =  
+001    9 m    O'Kelly, David                    1454 IRL        4273 1956/  /    3.0   13    20 b 0    16 w 1    13 b 1    23 w 1    14 w 0    10 b 0  
+001   10 m    Bradley, Michael                  1437 IRL        6756 1971/  /    4.0    6    21 w 1     4 b 0    24 w 1       - =     3 b =     9 w 1  
+001   11 m    Curtis, John W.                   1382 IRL        4088 1957/  /    1.0   22       - +     1 w 0    19 b 0    15 b 0     6 w 0       - -  
+001   12 m    Chan, Bryan                       1351 IRL       18137 2005/  /    4.5    3    23 w 0    17 b 1     6 w 1    20 b 1     1 w 1     4 b =  
+001   13 m    Hunter, Eoin                      1310 IRL       13512 2004/  /    2.0   18     1 b 0    18 w 1     9 w 0     2 b 0    21 w =    17 b =  
+001   14 m    Loughran, Gary                    1309            5428     .  .    4.0    4     2 w 1     6 b 1    20 w =       - =     9 b 1     5 w 0  
+001   15 m    Tempany, Max                      1302 IRL       17707 2003/  /    3.0   14     3 b 0     2 b 0    17 w 1    11 w 1     5 b 0     7 w 1  
+001   16 m    Scott, Shay                       1284 IRL        1537 1944/  /    1.0   21     4 w 0     9 b 0    18 w =    24 b 0    17 b =    23 w 0  
+001   17 m    Clancy, Stephen                   1259           N0001     .  .    1.5   20     5 b 0    12 w 0    15 b 0    18 b =    16 w =    13 w =  
+001   18 m    Farragher, Brian                  1259 IRL        0412 1970/  /    1.0   23     6 w 0    13 b 0    16 b =    17 w =     7 b 0    21 b 0  
+001   19 m    Murphy, Cathal                    1253 IRL       10570 1969/  /    2.5   16     8 b =    20 w =    11 w 1     6 b 0       - =    24 b 0  
+001   20 m    Kelly, Martin                     1235 IRL        0704 1952/  /    2.5   15     9 w 1    19 b =    14 b =    12 w 0    24 w =     2 b 0  
+001   21 m    Fitzpatrick, Kevin                1228 IRL        6968 1955/  /    2.5   17    10 b 0       - =       - -     7 w =    13 b =    18 w 1  
+001   23 m    Doyle, Peter                      1212 IRL       10237 1962/  /    3.0   12    12 b 1     3 w 0     7 w 1     9 b 0     2 w 0    16 b 1  
+001   24 m    Vaughan, Eoghan                   0000           N0002     .  .    3.5   10  0000 - +     5 w 0    10 b 0    16 w 1    20 b =    19 w 1  
+

--- a/spec/tournament_krause_spec.rb
+++ b/spec/tournament_krause_spec.rb
@@ -807,6 +807,12 @@ KRAUSE
           expect { @p.parse_file!(file) }.not_to raise_error
         end
 
+        it "should handle Cork Major 2018 (Swiss Master format)" do
+          file = "#{@s}/cork_major_2018_swissmaster.tab"
+          @t = @p.parse_file(file, :fed => :ignore)
+          check_results(1, 6, 3.5)
+        end
+
         it "should handle a file with a BOM" do
           file = "#{@s}/armstrong_2012_with_bom.tab"
           expect { @p.parse_file!(file) }.not_to raise_error


### PR DESCRIPTION
recent versions of SwissMaster use an empty field (four spaces "    ")
for a bye instead of the canonical "0000". We now parse that instead
of raising an error.